### PR TITLE
Issue 4: Fix disabled method EOS.undent

### DIFF
--- a/ahoy.rb
+++ b/ahoy.rb
@@ -10,7 +10,7 @@ class Ahoy < Formula
 
   depends_on "go" => :build
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOPLIST
 
     ===== UPGRADING FROM 1.x TO 2.x =====
 


### PR DESCRIPTION
Making this change in my local copy restored `brew info` Fixes #4 